### PR TITLE
Fix OBOE when iCurSection == SERPENT_LENGTH

### DIFF
--- a/src/Serpent.cpp
+++ b/src/Serpent.cpp
@@ -131,9 +131,9 @@ void Serpent::Update()
 	iTickSection--;
 	if((IsHead && iTickSection == 0) || (IsHead && iTickSection==7 && iCurSection == SERPENT_LENGTH))
 	{
-		if(iCurSection>=0)
+		if(iCurSection>0)
 		{
-			mSections[iCurSection].SpawnSection(StartPos);
+			mSections[iCurSection-1].SpawnSection(StartPos);
 			iCurSection--;
 			iTickSection = 10;
 		}


### PR DESCRIPTION
in line 136 of Serpent.cpp that causes vector::operator[] to fire an assert (and crash) on Debug mode because the subscript is out of range. Also change line 134 to avoid the same bug when iCurSection == 0.